### PR TITLE
移除多余的斜杠

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title:            SASNUI | ZHAO
 description:      这是一个叫三岁的人
-url:              https://buyivi.xyz/
+url:              https://buyivi.xyz
 permalink:        pretty
 timezone:         Asia/Urumqi
 kramdown:


### PR DESCRIPTION
site.url 以斜杠结尾，会导致生成的一些页面链接出现双斜杠。如RSS文件： https://buyivi.xyz/feed.xml 中就出现了错误的双斜杠链接。

```
<atom:link href="https://buyivi.xyz//feed.xml"
<link>https://buyivi.xyz//2021/03/26/qu-ta-qing/</link>
<guid isPermaLink="true">https://buyivi.xyz//2021/03/26/qu-ta-qing/</guid>
```